### PR TITLE
Correctly restore Target Group LB algorithm default

### DIFF
--- a/aws/resource_aws_alb_target_group_test.go
+++ b/aws/resource_aws_alb_target_group_test.go
@@ -454,6 +454,17 @@ func TestAccAWSALBTargetGroup_updateLoadBalancingAlgorithmType(t *testing.T) {
 		CheckDestroy:  testAccCheckAWSALBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
+				// Set to non-default first
+				Config: testAccAWSALBTargetGroupConfig_loadBalancingAlgorithm(targetGroupName, true, "least_outstanding_requests"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &conf),
+					resource.TestCheckResourceAttrSet("aws_alb_target_group.test", "arn"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "name", targetGroupName),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "load_balancing_algorithm_type", "least_outstanding_requests"),
+				),
+			},
+			{
+				// Verify default is restored
 				Config: testAccAWSALBTargetGroupConfig_loadBalancingAlgorithm(targetGroupName, false, ""),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &conf),
@@ -463,21 +474,13 @@ func TestAccAWSALBTargetGroup_updateLoadBalancingAlgorithmType(t *testing.T) {
 				),
 			},
 			{
+				// Explicitly set default
 				Config: testAccAWSALBTargetGroupConfig_loadBalancingAlgorithm(targetGroupName, true, "round_robin"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &conf),
 					resource.TestCheckResourceAttrSet("aws_alb_target_group.test", "arn"),
 					resource.TestCheckResourceAttr("aws_alb_target_group.test", "name", targetGroupName),
 					resource.TestCheckResourceAttr("aws_alb_target_group.test", "load_balancing_algorithm_type", "round_robin"),
-				),
-			},
-			{
-				Config: testAccAWSALBTargetGroupConfig_loadBalancingAlgorithm(targetGroupName, true, "least_outstanding_requests"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &conf),
-					resource.TestCheckResourceAttrSet("aws_alb_target_group.test", "arn"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "name", targetGroupName),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "load_balancing_algorithm_type", "least_outstanding_requests"),
 				),
 			},
 		},

--- a/aws/resource_aws_lb_target_group.go
+++ b/aws/resource_aws_lb_target_group.go
@@ -124,7 +124,7 @@ func resourceAwsLbTargetGroup() *schema.Resource {
 			"load_balancing_algorithm_type": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Computed: true,
+				Default:  "round_robin",
 				ValidateFunc: validation.StringInSlice([]string{
 					"round_robin",
 					"least_outstanding_requests",


### PR DESCRIPTION
Closes
https://github.com/terraform-providers/terraform-provider-aws/issues/12297

<!--- See what makes a good Pull Request at : https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/CONTRIBUTING.md#pull-requests --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Release note for [CHANGELOG](https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note

```

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTARGS='-run=TestAccXXX'

...
```
