### PR TITLE
Revert "Correctly restore Target Group LB algorithm default"

### DIFF
--- a/aws/resource_aws_alb_target_group_test.go
+++ b/aws/resource_aws_alb_target_group_test.go
@@ -454,17 +454,6 @@ func TestAccAWSALBTargetGroup_updateLoadBalancingAlgorithmType(t *testing.T) {
 		CheckDestroy:  testAccCheckAWSALBTargetGroupDestroy,
 		Steps: []resource.TestStep{
 			{
-				// Set to non-default first
-				Config: testAccAWSALBTargetGroupConfig_loadBalancingAlgorithm(targetGroupName, true, "least_outstanding_requests"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &conf),
-					resource.TestCheckResourceAttrSet("aws_alb_target_group.test", "arn"),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "name", targetGroupName),
-					resource.TestCheckResourceAttr("aws_alb_target_group.test", "load_balancing_algorithm_type", "least_outstanding_requests"),
-				),
-			},
-			{
-				// Verify default is restored
 				Config: testAccAWSALBTargetGroupConfig_loadBalancingAlgorithm(targetGroupName, false, ""),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &conf),
@@ -474,13 +463,21 @@ func TestAccAWSALBTargetGroup_updateLoadBalancingAlgorithmType(t *testing.T) {
 				),
 			},
 			{
-				// Explicitly set default
 				Config: testAccAWSALBTargetGroupConfig_loadBalancingAlgorithm(targetGroupName, true, "round_robin"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &conf),
 					resource.TestCheckResourceAttrSet("aws_alb_target_group.test", "arn"),
 					resource.TestCheckResourceAttr("aws_alb_target_group.test", "name", targetGroupName),
 					resource.TestCheckResourceAttr("aws_alb_target_group.test", "load_balancing_algorithm_type", "round_robin"),
+				),
+			},
+			{
+				Config: testAccAWSALBTargetGroupConfig_loadBalancingAlgorithm(targetGroupName, true, "least_outstanding_requests"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &conf),
+					resource.TestCheckResourceAttrSet("aws_alb_target_group.test", "arn"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "name", targetGroupName),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "load_balancing_algorithm_type", "least_outstanding_requests"),
 				),
 			},
 		},

--- a/aws/resource_aws_lb_target_group.go
+++ b/aws/resource_aws_lb_target_group.go
@@ -124,7 +124,7 @@ func resourceAwsLbTargetGroup() *schema.Resource {
 			"load_balancing_algorithm_type": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "round_robin",
+				Computed: true,
 				ValidateFunc: validation.StringInSlice([]string{
 					"round_robin",
 					"least_outstanding_requests",


### PR DESCRIPTION
Reverts Root-App/terraform-provider-aws#7

Need to change this to only apply to Application Load Balancers without target type set to Lambda